### PR TITLE
Version 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [B_Ruge]
 
+### [0.2.8] - 19.09.2021
+
+#### Added
+
+* Added badge for web deployment preview to readme
+* Added components and system to allow entities to drop items
+* Added render order for entities and tiles
+* Added components for the creation of items
+* Added health potion item
+* Added system to pick up and use items
+* Added item and potion components
+* Added potion usage system
+* Added inventory dialog
+* Added seeded random number generator
+
+#### Changed
+
+* Bumped version to 0.2.8 
+* Game is now initialized with a seed based on the current time in nanoseconds
+* Started to move plain text exception messages to a custom module for better maintainability
+* Removed unnecessary domain alias from web preview deployment workflow yaml
+* Separated web deployment workflow into preview for dev and production for main
+* Reworked DialogInterface and DialogOptions to now incorporate a memory safe generic way to create callbacks and 
+make them safely callable at any part of the game
+* Reworked entity_factory spawning
+* Modified deploy_web.yml to fire when pushed on dev and when a pull request is set for the main branch* Modified
+deploy_web.yml to fire when pushed on dev and when a pull request is set for the main branch
+* Update CHANGELOG.md
+* Finished documentation for next release
+* Moved remaining hardcoded colors to swatch 
+* Updated manifest.json in the web templates to show the games correct name
+* Updated inventory text for use and drop item
+* Extended documentation
+
+#### Fixes
+
+* Fixed display issue of workflow badge deploy-web
+* Corrected error in dialog display logic, causing dialogs without a text to display items of center 
+
 ### [0.2.7] - 11.09.2021
 
 #### Added
@@ -65,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Initial release which only shows the apps window in a simple hello world manner.
 
 [B_Ruge]: https://github.com/SebastianRiga/B_Ruge
+[0.2.8]: https://github.com/SebastianRiga/B_Ruge/Releases/Tag/v0.2.8
 [0.2.7]: https://github.com/SebastianRiga/B_Ruge/releases/tag/v0.2.7
 [0.2.6]: https://github.com/SebastianRiga/B_Ruge/releases/tag/v0.2.6
 [0.2.5]: https://github.com/SebastianRiga/B_Ruge/releases/tag/v0.2.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "b_ruge"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "b_ruge"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2018"
 description = "D&D and NetHack inspired dungeon crawler written in rust."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # B_Ruge
 
-[![Web (Production)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web.yml/badge.svg?branch=main&event=pull_request)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web.yml)
+[![Web (Production)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web_prod.yml/badge.svg)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web_prod.yml)
 [![Web (Preview)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web_dev.yml/badge.svg?branch=dev&event=push)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web_dev.yml)
 
 D&D and NetHack inspired dungeon crawler written in rust.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # B_Ruge
 
-[![Rust](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web.yml/badge.svg?branch=main&event=pull_request)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web.yml)
+[![Web (Production)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web.yml/badge.svg?branch=main&event=pull_request)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web.yml)
+[![Web (Preview)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web_dev.yml/badge.svg?branch=dev&event=push)](https://github.com/SebastianRiga/B_Ruge/actions/workflows/deploy_web_dev.yml)
 
 D&D and NetHack inspired dungeon crawler written in rust.
 Based on the awesome tutorial written by Herbert Wolverson available at

--- a/src/components.rs
+++ b/src/components.rs
@@ -99,7 +99,7 @@ pub struct Renderable {
 
     /// Background color of the entity.
     pub bg: RGB,
-    
+
     /// Place in the rendering order
     pub order: i32,
 }
@@ -215,8 +215,7 @@ impl DamageCounter {
                 damage_values: vec![amount],
             };
 
-            let on_error_message =
-                exceptions::get_add_damage_amount_error_message(&target, amount);
+            let on_error_message = exceptions::get_add_damage_amount_error_message(&target, amount);
 
             store
                 .insert(target, damage_counter)
@@ -315,15 +314,15 @@ pub struct Potion {
 impl Potion {
     /// Adds a request to the passed `ecs`, that the `user` [Entity] wants to
     /// drink the supplied `potion` [Entity].
-    /// 
+    ///
     /// # Arguments
     /// * `ecs`: The overarching `ecs` to write to.
     /// * `user`: The [Entity] that wants to drink the `potion`.
     /// * `potion`: The `potion` [Entity] the `user` wants to drink.
-    /// 
+    ///
     pub fn drink(ecs: &World, user: &Entity, potion: &Entity) {
         let mut usage_intent = ecs.write_storage::<UsePotion>();
-        
+
         let usage = UsePotion { potion: *potion };
 
         usage_intent.insert(*user, usage).expect("");

--- a/src/components.rs
+++ b/src/components.rs
@@ -289,7 +289,14 @@ impl Item {
         };
     }
 
-    /// TODO: Add documentation
+    /// Drops an [Item] [Entity] from the inventory of the `owner`
+    /// [Entity].
+    ///
+    /// # Arguments
+    /// * `ecs`: The [World] in which both the `owner` and `item` are stored.
+    /// * `owner`: The `owner` [Entity] of the `item`.
+    /// * `item`: The [Item] that the `owner` wants to drop.
+    ///
     pub fn drop_item(ecs: &World, owner: &Entity, item: &Entity) {
         let mut drop_intent = ecs.write_storage::<DropItem>();
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -332,7 +332,9 @@ impl Potion {
 
         let usage = UsePotion { potion: *potion };
 
-        usage_intent.insert(*user, usage).expect("");
+        let error_message = exceptions::get_drink_potion_error_message(user, potion);
+
+        usage_intent.insert(*user, usage).expect(&error_message);
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@
 use rltk::console;
 
 /// The current version of the game.
-pub const GAME_VERSION: &'static str = "v0.2.7";
+pub const GAME_VERSION: &'static str = "v0.2.8";
 
 /// The name of the game, needed for display on the
 /// window and in-game.

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,11 +33,19 @@ pub const MIN_ROOM_SIZE: i32 = 6;
 /// the map.
 pub const MAX_ROOM_SIZE: i32 = 10;
 
-/// The maximum amount of
+/// The maximum amount of monsters, that can be spawned in a single room of the game.
 pub const MAX_MONSTERS_PER_ROOM: i32 = 4;
 
+/// The maximum amount of items, that can be spawned in a single room of the game.
 pub const MAX_ITEMS_PER_ROOM: i32 = 2;
 
+/// Prints the games logo, copyright notice and current
+/// version to the console. 
+/// 
+/// # Notes
+/// * If the game is running in a browser through web assembly, the
+/// message is printed to the browsers debug console.
+/// 
 pub fn log_starting_message() {
     let message = format!(
         r#"

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,12 +40,12 @@ pub const MAX_MONSTERS_PER_ROOM: i32 = 4;
 pub const MAX_ITEMS_PER_ROOM: i32 = 2;
 
 /// Prints the games logo, copyright notice and current
-/// version to the console. 
-/// 
+/// version to the console.
+///
 /// # Notes
 /// * If the game is running in a browser through web assembly, the
 /// message is printed to the browsers debug console.
-/// 
+///
 pub fn log_starting_message() {
     let message = format!(
         r#"

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -122,7 +122,7 @@ impl DialogInterface {
     pub fn show(&mut self, ecs: &World, terminal: &mut Rltk) -> DialogResult {
         // Calculate the width and height for the dialog
         let message_length = match &self.message {
-            None => 0 as f32,
+            None => 1 as f32,
             Some(message) => message.len() as f32,
         };
 
@@ -159,14 +159,14 @@ impl DialogInterface {
                 terminal.print(x + 2, y_position, chunk);
                 y_position += 1;
             }
-
-            y_position += 1;
         }
+
+        y_position += 1;
 
         let (fg, bg) = swatch::DIALOG_OPTION.colors();
 
         // Draw the dialog's options
-        for option in self.options.iter() {
+        for (_, option) in self.options.iter().enumerate() {
             let key_string = virtual_key_code_to_string(option.key);
             terminal.print_color(
                 x + 2,
@@ -175,6 +175,7 @@ impl DialogInterface {
                 bg,
                 &format!("{} - {}", key_string, option.description),
             );
+
             y_position += 2;
         }
 

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -2,10 +2,10 @@
 
 use std::any::Any;
 
-use rltk::{Rltk, VirtualKeyCode, RGB};
+use rltk::{Rltk, VirtualKeyCode};
 use specs::prelude::*;
 
-use super::{config, virtual_key_code_to_string};
+use super::{config, swatch, virtual_key_code_to_string};
 
 /// Enum describing all the results
 /// a [DialogInterface] can return when it is shown.
@@ -134,24 +134,15 @@ impl DialogInterface {
         let x = (config::MAP_WIDTH / 2) - (width / 2);
         let y = (config::MAP_HEIGHT / 2) - (height / 2);
 
+        let (fg, bg) = swatch::DIALOG_FRAME.colors();
+
         // Draw the dialog's box
-        terminal.draw_box(
-            x,
-            y,
-            width,
-            height,
-            RGB::named(rltk::WHITE),
-            RGB::named(rltk::DARK_GOLDENROD),
-        );
+        terminal.draw_box(x, y, width, height, fg, bg);
+
+        let (fg, bg) = swatch::DIALOG_TITLE.colors();
 
         // Draw the dialog's title
-        terminal.print_color(
-            x + 2,
-            y,
-            RGB::named(rltk::WHITE),
-            RGB::named(rltk::BLACK),
-            &format!("{}", self.title),
-        );
+        terminal.print_color(x + 2, y, fg, bg, &format!("{}", self.title));
 
         let mut y_position = y + 2;
 
@@ -172,14 +163,16 @@ impl DialogInterface {
             y_position += 1;
         }
 
+        let (fg, bg) = swatch::DIALOG_OPTION.colors();
+
         // Draw the dialog's options
         for option in self.options.iter() {
             let key_string = virtual_key_code_to_string(option.key);
             terminal.print_color(
                 x + 2,
                 y_position,
-                RGB::named(rltk::YELLOW),
-                RGB::named(rltk::BLACK),
+                fg,
+                bg,
                 &format!("{} - {}", key_string, option.description),
             );
             y_position += 2;
@@ -188,11 +181,13 @@ impl DialogInterface {
         // If the dialog is cancelable, print the `dismiss` option
         // at the bottom.
         if self.cancelable {
+            let (fg, bg) = swatch::DIALOG_DISMISS_BUTTON.colors();
+
             terminal.print_color(
                 x + 2,
                 y + height,
-                RGB::named(rltk::WHITE),
-                RGB::named(rltk::BLACK),
+                fg,
+                bg,
                 &format!("{} - {}", "ESCAPE", "Dismiss"),
             )
         }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -121,7 +121,6 @@ impl DialogInterface {
     ///
     pub fn show(&mut self, ecs: &World, terminal: &mut Rltk) -> DialogResult {
         // Calculate the width and height for the dialog
-
         let message_length = match &self.message {
             None => 0 as f32,
             Some(message) => message.len() as f32
@@ -132,12 +131,10 @@ impl DialogInterface {
         height += (self.options.len() * 2) as i32 + 3;
 
         // Calculate the x and y coordinate for the dialog
-
         let x = (config::MAP_WIDTH / 2) - (width / 2);
         let y = (config::MAP_HEIGHT / 2) - (height / 2);
 
         // Draw the dialog's box
-
         terminal.draw_box(
             x,
             y,
@@ -148,7 +145,6 @@ impl DialogInterface {
         );
 
         // Draw the dialog's title
-
         terminal.print_color(
             x + 2,
             y,
@@ -160,7 +156,6 @@ impl DialogInterface {
         let mut y_position = y + 2;
         
         // Draw the message if present
-
         if let Some(message) = &self.message {
             // Split the message into chunks that fit into the dialogs frame
             let message_chunks = message
@@ -178,7 +173,6 @@ impl DialogInterface {
         }
         
         // Draw the dialog's options
-
         for option in self.options.iter() {
             let key_string = virtual_key_code_to_string(option.key);
             terminal.print_color(
@@ -191,6 +185,8 @@ impl DialogInterface {
             y_position += 2;
         }
 
+        // If the dialog is cancelable, print the `dismiss` option 
+        // at the bottom.
         if self.cancelable {
             terminal.print_color(
                 x + 2,
@@ -202,7 +198,6 @@ impl DialogInterface {
         }
 
         // Listen for key press event
-
         if let Some(key) = terminal.key {
             let selection = self.options.iter_mut().find(|element| element.key == key);
 
@@ -211,6 +206,8 @@ impl DialogInterface {
                 return DialogResult::Consumed;
             }
 
+            // If the dialog is cancelable, check if the `escape` key
+            // was pressed.
             if self.cancelable {
                 if key == VirtualKeyCode::Escape {
                     return DialogResult::Consumed;
@@ -218,6 +215,8 @@ impl DialogInterface {
             }
         }
 
+        // If no key was pressed by the user, return the waiting state to try again in
+        // the next frame
         DialogResult::Waiting
     }
 }

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -123,9 +123,9 @@ impl DialogInterface {
         // Calculate the width and height for the dialog
         let message_length = match &self.message {
             None => 0 as f32,
-            Some(message) => message.len() as f32
+            Some(message) => message.len() as f32,
         };
-        
+
         let width = (config::MAP_WIDTH as f32 / 2.5) as i32;
         let mut height = (message_length / width as f32).ceil() as i32;
         height += (self.options.len() * 2) as i32 + 3;
@@ -154,7 +154,7 @@ impl DialogInterface {
         );
 
         let mut y_position = y + 2;
-        
+
         // Draw the message if present
         if let Some(message) = &self.message {
             // Split the message into chunks that fit into the dialogs frame
@@ -171,7 +171,7 @@ impl DialogInterface {
 
             y_position += 1;
         }
-        
+
         // Draw the dialog's options
         for option in self.options.iter() {
             let key_string = virtual_key_code_to_string(option.key);
@@ -185,7 +185,7 @@ impl DialogInterface {
             y_position += 2;
         }
 
-        // If the dialog is cancelable, print the `dismiss` option 
+        // If the dialog is cancelable, print the `dismiss` option
         // at the bottom.
         if self.cancelable {
             terminal.print_color(

--- a/src/entity_factory.rs
+++ b/src/entity_factory.rs
@@ -109,6 +109,12 @@ pub fn new_gremlin(ecs: &mut World, position: Position, suffix: Option<String>) 
     new_monster(ecs, name, renderable, statistic, position)
 }
 
+/// Creates a new [Potion] entity at the supplied `position` in the passed `ecs`.
+/// 
+/// # Arguments
+/// * `ecs`: The [World] in which the `potion` should be created.
+/// * `position`: The [Position] at which the potion should be placed.
+/// 
 pub fn new_health_potion(ecs: &mut World, position: Position) -> Entity {
     let (fg, bg) = swatch::HEALTH_POTION.colors();
 
@@ -128,6 +134,12 @@ pub fn new_health_potion(ecs: &mut World, position: Position) -> Entity {
         .build()
 }
 
+/// Creates a random monster in the `ecs` at the passed `position`.
+/// 
+/// * Arguments
+/// * `ecs`: The [World] in which the monster should be created.
+/// * `position`: The [Position] at which the monster should be placed.
+/// 
 pub fn random_monster(ecs: &mut World, position: Position) -> Entity {
     let creator = [new_goblin, new_gremlin];
     let upper_bound = creator.len() as i32;
@@ -137,6 +149,16 @@ pub fn random_monster(ecs: &mut World, position: Position) -> Entity {
     (creator[index])(ecs, position, None)
 }
 
+/// Creates a new monster in the passed `ecs` and attaches the supplied
+/// `name`, `renderable`, `statistic` and `position` components.
+/// 
+/// # Arguments
+/// * `ecs`: The [World] the monster should be added to.
+/// * `name`: The [Name] of the monster.
+/// * `renderable`: The [Renderable] information of the monster.
+/// * `statistic`: The [Statistic] data of the monster for battle.
+/// * `position`: The [Position] of the monster in the world.
+/// 
 fn new_monster(
     ecs: &mut World,
     name: Name,

--- a/src/entity_factory.rs
+++ b/src/entity_factory.rs
@@ -96,7 +96,7 @@ pub fn new_gremlin(ecs: &mut World, position: Position, suffix: Option<String>) 
         symbol: rltk::to_cp437('g'),
         fg,
         bg,
-        order: 1
+        order: 1,
     };
 
     let statistic = Statistics {
@@ -110,11 +110,11 @@ pub fn new_gremlin(ecs: &mut World, position: Position, suffix: Option<String>) 
 }
 
 /// Creates a new [Potion] entity at the supplied `position` in the passed `ecs`.
-/// 
+///
 /// # Arguments
 /// * `ecs`: The [World] in which the `potion` should be created.
 /// * `position`: The [Position] at which the potion should be placed.
-/// 
+///
 pub fn new_health_potion(ecs: &mut World, position: Position) -> Entity {
     let (fg, bg) = swatch::HEALTH_POTION.colors();
 
@@ -124,7 +124,7 @@ pub fn new_health_potion(ecs: &mut World, position: Position) -> Entity {
             symbol: rltk::to_cp437('!'),
             fg,
             bg,
-            order: 2
+            order: 2,
         })
         .with(Name {
             name: "Health Potion".to_string(),
@@ -135,11 +135,11 @@ pub fn new_health_potion(ecs: &mut World, position: Position) -> Entity {
 }
 
 /// Creates a random monster in the `ecs` at the passed `position`.
-/// 
+///
 /// * Arguments
 /// * `ecs`: The [World] in which the monster should be created.
 /// * `position`: The [Position] at which the monster should be placed.
-/// 
+///
 pub fn random_monster(ecs: &mut World, position: Position) -> Entity {
     let creator = [new_goblin, new_gremlin];
     let upper_bound = creator.len() as i32;
@@ -151,14 +151,14 @@ pub fn random_monster(ecs: &mut World, position: Position) -> Entity {
 
 /// Creates a new monster in the passed `ecs` and attaches the supplied
 /// `name`, `renderable`, `statistic` and `position` components.
-/// 
+///
 /// # Arguments
 /// * `ecs`: The [World] the monster should be added to.
 /// * `name`: The [Name] of the monster.
 /// * `renderable`: The [Renderable] information of the monster.
 /// * `statistic`: The [Statistic] data of the monster for battle.
 /// * `position`: The [Position] of the monster in the world.
-/// 
+///
 fn new_monster(
     ecs: &mut World,
     name: Name,

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -46,3 +46,31 @@ pub fn get_drop_item_error_message(owner: &Entity, item: &Entity) -> String {
         item.id()
     )
 }
+
+/// Returns the error message for the `UsePotion` systen, when the insertion
+/// of a use potion request failes.
+/// 
+/// # Arguments
+/// * `user`: The [Entity] that wants to drink the `potion`.
+/// * `potion`: The `potion` [Entity] the `user` wants to drink.
+/// 
+pub fn get_drink_potion_error_message(user: &Entity, potion: &Entity) -> String {
+    format!(
+        "Unable to insert use potion request for user with id {} and potion with id {}",
+        user.id(),
+        potion.id()
+    )
+}
+
+/// Returns the error message for `MeleeCombatSystem` system, used when the
+/// adding of a melee attack from a monster against the player fails.
+/// 
+/// #A Arguments
+/// * `monster`: The [Entity] attacking the player.
+/// 
+pub fn get_add_melee_damage_error_message(monster: &Entity) -> String {
+    format!(
+        "Adding melee attack from monster with id {} against player failed!",
+        monster.id()
+    )
+}

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,7 +1,6 @@
 //! Module for custom exceptions and exception messages
 
 /// TODO: Finish documentation
-
 use specs::Entity;
 
 pub fn get_add_damage_amount_error_message(target: &Entity, amount: i32) -> String {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,5 +1,7 @@
 //! Module for custom exceptions and exception messages
 
+/// TODO: Finish documentation
+
 use specs::Entity;
 
 pub fn get_add_damage_amount_error_message(target: &Entity, amount: i32) -> String {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -1,8 +1,14 @@
-//! Module for custom exceptions and exception messages
+//! Module for custom exceptions and error messages.
 
-/// TODO: Finish documentation
 use specs::Entity;
 
+/// Returns the `error message` for the `DamageSystem`, when the storing of
+/// any damage `amount` for the `target` [Entity].
+///
+/// # Arguments
+/// * `target`: The [Entity] for which the damage `amount` couldn't be added.
+/// * `amount`: The `amount` of damage, that should have been added to the `target` [Entity].
+///
 pub fn get_add_damage_amount_error_message(target: &Entity, amount: i32) -> String {
     format!(
         "Damage amount {} couldn't be stored in the ecs for entity with id {}",
@@ -11,6 +17,13 @@ pub fn get_add_damage_amount_error_message(target: &Entity, amount: i32) -> Stri
     )
 }
 
+/// Returns the `error message`for the `ItemCollectionSystem`, when the picking up of
+/// an item [Entity] has failed for the passed `collector` [Entity].
+///
+/// # Arguments
+/// * `collector`: The [Entity] that wants to pick up the `item`.
+/// * `item`: The item [Entity], which the `collector` is trying to pickup.
+///
 pub fn get_pick_up_item_error_message(collector: &Entity, item: &Entity) -> String {
     format!(
         "Unable to pick up item with id {} and add it to inventory of collector with id {}!",
@@ -19,6 +32,13 @@ pub fn get_pick_up_item_error_message(collector: &Entity, item: &Entity) -> Stri
     )
 }
 
+/// Returns the error message for the `DropItemSystem`, when the droping of an
+/// item [Entity] fails for the passed `owner` entity.
+///
+/// # Arguments
+/// * `owner`: The current owning [Entity], which is trying to drop the `item` [Entity].
+/// * `item`: The item [Entity] the `owner` is trying to drop.
+///
 pub fn get_drop_item_error_message(owner: &Entity, item: &Entity) -> String {
     format!(
         "Unable to drop item with id {} from inventory of owner with id {}!",

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,5 +1,7 @@
 //! Collection of functions for the player.
 
+/// TODO: Finish documentation
+
 use std::cmp::{max, min};
 
 use rltk::{a_star_search, Point, Rltk, VirtualKeyCode};

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,7 +1,6 @@
 //! Collection of functions for the player.
 
 /// TODO: Finish documentation
-
 use std::cmp::{max, min};
 
 use rltk::{a_star_search, Point, Rltk, VirtualKeyCode};
@@ -154,7 +153,7 @@ fn show_inventory(ecs: &mut World, drop: bool) {
                     let item = *args[0].downcast_ref::<Entity>().unwrap();
                     let player = *args[1].downcast_ref::<Entity>().unwrap();
                     let is_dropping_item = *args[2].downcast_ref::<bool>().unwrap();
-                    
+
                     if is_dropping_item {
                         Item::drop_item(world, &player, &item);
                     } else {
@@ -166,7 +165,7 @@ fn show_inventory(ecs: &mut World, drop: bool) {
             counter += 1;
         }
     }
-    
+
     let title = if drop {
         "Select item to drop".to_string()
     } else {
@@ -176,7 +175,7 @@ fn show_inventory(ecs: &mut World, drop: bool) {
     let message = if options.is_empty() {
         Some("You backpack is empty...".to_string())
     } else {
-       None
+        None
     };
 
     DialogInterface::register_dialog(ecs, title, message, options, true);

--- a/src/player.rs
+++ b/src/player.rs
@@ -202,19 +202,21 @@ fn show_inventory(ecs: &mut World, drop: bool) {
         }
     }
 
-    let title = if drop {
-        "Select item to drop".to_string()
-    } else {
-        "Inventory".to_string()
-    };
-
     let message = if options.is_empty() {
-        Some("You backpack is empty...".to_string())
+        if drop {
+            "No items to drop...".to_string()
+        } else {
+            "You backpack is empty...".to_string()
+        }
     } else {
-        None
+        if drop {
+            "Select item to drop".to_string()
+        } else {
+            "Select an item to use/equip".to_string()
+        }
     };
 
-    DialogInterface::register_dialog(ecs, title, message, options, true);
+    DialogInterface::register_dialog(ecs, "Inventory".to_string(), Some(message), options, true);
 }
 
 /// Fetches the player [Entity] from the [World]

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,7 +1,6 @@
 //! Module for random number generation
 
 /// TODO: Add documentation
-
 use chrono::Utc;
 use rltk::{console, RandomNumberGenerator};
 use specs::prelude::*;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,5 +1,7 @@
 //! Module for random number generation
 
+/// TODO: Add documentation
+
 use chrono::Utc;
 use rltk::{console, RandomNumberGenerator};
 use specs::prelude::*;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,10 +1,21 @@
 //! Module for random number generation
 
-/// TODO: Add documentation
 use chrono::Utc;
 use rltk::{console, RandomNumberGenerator};
 use specs::prelude::*;
 
+/// Registers a the `rng` handler with the passed `ecs`.
+///
+/// # Arguments
+/// * `ecs`: The [World] in which the `rng` handler should be registered.
+///
+/// Notes
+/// * The seed for the `rng` handler is calculated through the current
+/// system time in nanoseconds.
+/// * This action must be performed befor any other function from the module
+/// can be safely called! If no handler is registered all other functions
+/// will panic!
+///
 pub fn register(ecs: &mut World) {
     let seed = Utc::now().timestamp_nanos() as u64;
     let rng = RandomNumberGenerator::seeded(seed);
@@ -14,6 +25,19 @@ pub fn register(ecs: &mut World) {
     ecs.insert(rng);
 }
 
+/// Rolls dice, using the classic 3d6 type.
+///
+/// # Arguments
+/// * `ecs`: The [World] with which the `rng` handler was registered.
+/// * `n`: The number of dice
+/// * `die_type`: Size of the dice / Amount of sides.
+///
+/// # Panics
+/// * If no `rng` handler is registered in the passed `ecs`.
+///
+/// # See also
+/// * [register]
+///
 pub fn roll_dice(ecs: &mut World, n: i32, die_type: i32) -> i32 {
     if is_registered(ecs) {
         let mut rng = ecs.write_resource::<RandomNumberGenerator>();
@@ -22,6 +46,18 @@ pub fn roll_dice(ecs: &mut World, n: i32, die_type: i32) -> i32 {
     panic!("Called 'roll_dice' function of module rng without registering it with the ecs!");
 }
 
+/// Returns a random number in the range from `start` to `end`.
+/// The range includes the `start` parameter but excludes the `end`
+/// parameter!
+///
+/// # Arguments
+/// * `ecs`: The [World] in which the `rng` handler is registered.
+/// * `start`: The start of the range from which the random number should be picked (Inclusive!).
+/// * `end`: The end of the range from which the random number should be picked (Exclusive!).
+///
+/// # Panics
+/// * If no `rng` handler is registered in the
+///
 pub fn range(ecs: &mut World, start: i32, end: i32) -> i32 {
     if is_registered(ecs) {
         let mut rng = ecs.write_resource::<RandomNumberGenerator>();
@@ -30,6 +66,12 @@ pub fn range(ecs: &mut World, start: i32, end: i32) -> i32 {
     panic!("Called 'roll_dice' function of module rng without registering it with the ecs!");
 }
 
+/// Shorthand convenience function that returns `true` if
+/// a `rng` handler is registered with the passed `ecs`.
+///
+/// # Arguments
+/// * `ecs`: The [World] to check for a registered `rng` handler.
+///
 fn is_registered(ecs: &mut World) -> bool {
     ecs.has_value::<RandomNumberGenerator>()
 }

--- a/src/spawn_controller.rs
+++ b/src/spawn_controller.rs
@@ -1,7 +1,6 @@
 //! Module for spawning monsters, items and general entities.
 
 /// TODO: Add documentation
-
 use super::{config, entity_factory, rng, Position, Rectangle};
 use specs::prelude::*;
 

--- a/src/spawn_controller.rs
+++ b/src/spawn_controller.rs
@@ -1,9 +1,19 @@
 //! Module for spawning monsters, items and general entities.
 
-/// TODO: Add documentation
 use super::{config, entity_factory, rng, Position, Rectangle};
 use specs::prelude::*;
 
+/// Spawns monsters and items in the passed room [Rectangle],
+/// based on the parameters set in the game's [config].
+///
+/// # Arguments
+/// * `ecs`: The [World] in which the [Entity] structs will be saved.
+/// * `room`: The room from the [Map] in which the monsters and items
+/// should be spawned.
+///
+/// # See also
+/// * [place_entities_in_room]
+///
 pub fn spawn_in_room(ecs: &mut World, room: &Rectangle) {
     let mut monster_spawn_positions: Vec<Position> = Vec::new();
     let mut item_spawn_positions: Vec<Position> = Vec::new();
@@ -28,6 +38,18 @@ pub fn spawn_in_room(ecs: &mut World, room: &Rectangle) {
     }
 }
 
+/// Convenience function that creates monster or item entities
+/// in accordance to the passed `max_placement` parameter and
+/// the positions which are already occupied by a monster as
+/// indicated biy the container [Vec]
+///
+/// # Arguments
+/// * `ecs`: The [World] in which the entities should be stored.
+/// * `max_placements`: Maximum amount of entities that can be placed.
+/// * `room`: Reference to the room [Rectangle] from the [Map], in which
+/// the entities should be placed.
+/// * `container`: [Vec] storing the spawn positions of the monsters.
+///  
 fn place_entities_in_room(
     ecs: &mut World,
     max_placements: i32,

--- a/src/spawn_controller.rs
+++ b/src/spawn_controller.rs
@@ -1,5 +1,7 @@
 //! Module for spawning monsters, items and general entities.
 
+/// TODO: Add documentation
+
 use super::{config, entity_factory, rng, Position, Rectangle};
 use specs::prelude::*;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,7 @@
 //! Game state handling module
 
+/// TODO: Finish documentation
+
 use rltk::{GameState, Rltk};
 use specs::prelude::*;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,15 +1,13 @@
-//! Game state handling module
+//! Game state handling module.
 
-/// TODO: Finish documentation
 use rltk::{GameState, Rltk};
 use specs::prelude::*;
 
 use super::{
     player_handle_input, ui_controller, DamageSystem, DialogInterface, DialogResult, FOVSystem,
-    ItemCollectionSystem, Map, MapDexSystem, MeleeCombatSystem, MonsterAI, Position,
-    PotionDrinkSystem, Renderable,
+    ItemCollectionSystem, ItemDropSystem, Map, MapDexSystem, MeleeCombatSystem, MonsterAI,
+    Position, PotionDrinkSystem, Renderable,
 };
-use crate::ItemDropSystem;
 
 /// Struct describing the current state of the game
 /// and providing access to the underlying `ECS`
@@ -50,7 +48,13 @@ impl State {
         self.ecs.maintain();
     }
 
-    fn get_current_processing_state(&self) -> ProcessingState {
+    /// Returns the current [ProcessingState] of the
+    /// system
+    ///
+    /// # Note
+    /// * If a [DialogInterface] has been registered,
+    /// the function always returns [ProcessingState::Dialog].
+    fn get_processing_state(&self) -> ProcessingState {
         let has_dialog = self.ecs.has_value::<DialogInterface>();
 
         let next_processing_state: ProcessingState;
@@ -66,6 +70,17 @@ impl State {
         return next_processing_state;
     }
 
+    /// Updates the saved [ProcessingState] with the passed value,
+    /// by writting it into the `ecs` resource.
+    ///
+    /// # Arguments
+    /// * `new_processing_state`: The new [ProcessingState] of the system.
+    ///
+    fn set_processing_state(&self, new_processing_state: &ProcessingState) {
+        let mut writter = self.ecs.write_resource::<ProcessingState>();
+        *writter = *new_processing_state;
+    }
+
     /// Displays the ui of the game on the screen, this includes
     /// the map, message log, status information etc.
     ///
@@ -73,9 +88,11 @@ impl State {
     /// * `ctx`: The context in which the ui should be drawn.
     ///
     fn show_ui(&self, ctx: &mut Rltk) {
+        // Fetch the map from the ecs and draw it
         let map = self.ecs.fetch::<Map>();
         map.draw(ctx);
 
+        // Draw base ui
         ui_controller::draw_ui(&self.ecs, ctx);
 
         // Get all entities with [Position] and [Renderable]
@@ -83,9 +100,13 @@ impl State {
         let positions = self.ecs.read_storage::<Position>();
         let renderers = self.ecs.read_storage::<Renderable>();
 
+        // Join get all renderables with a position and collect them in a vec for sorting
         let mut entities = (&positions, &renderers).join().collect::<Vec<_>>();
+
+        // Sort all tuples by the render order set in the renderable
         entities.sort_by(|&first, &second| second.1.order.cmp(&first.1.order));
 
+        // Render entities
         for (position, renderable) in entities.iter() {
             if map.is_tile_in_fov(position.x, position.y) {
                 ctx.set(
@@ -97,8 +118,20 @@ impl State {
                 )
             }
         }
+
+        // Draw the tooltip as the top most ui element. (Only dialogs are higer)
+        ui_controller::draw_tooltips(&self.ecs, ctx);
     }
 
+    /// Fetches the currently saved dialog from the `ecs` and
+    /// displays it.
+    ///
+    /// # Arguments
+    /// * `ctx`: The [Rltk] context in which the dialog should be drawn.ui_controller
+    ///
+    /// # Panics
+    /// * If no dialog is stored in the `ecs`.
+    ///
     fn show_dialog(&mut self, ctx: &mut Rltk) -> DialogResult {
         let mut dialog = self.ecs.fetch_mut::<DialogInterface>();
         dialog.show(&self.ecs, ctx)
@@ -119,7 +152,7 @@ impl GameState for State {
 
         let mut show_dialog = false;
 
-        let mut next_processing_state = self.get_current_processing_state();
+        let mut next_processing_state = self.get_processing_state();
 
         match next_processing_state {
             ProcessingState::Dialog => {
@@ -147,6 +180,7 @@ impl GameState for State {
             }
         }
 
+        // Remove all dead/defeated entities from the `ecs`
         DamageSystem::clean_up(&mut self.ecs);
 
         // Standard render process
@@ -161,10 +195,7 @@ impl GameState for State {
         }
 
         // Update the processing state
-        {
-            let mut run_writer = self.ecs.write_resource::<ProcessingState>();
-            *run_writer = next_processing_state;
-        }
+        self.set_processing_state(&next_processing_state);
     }
 }
 
@@ -177,9 +208,9 @@ pub enum ProcessingState {
     /// passes control to the player.
     Internal,
 
-    /// The is displaying a dialog and
-    /// is waiting for a key press for
-    /// current dialog.
+    /// The system is displaying a dialog
+    /// andis waiting for a key press on
+    /// the current dialog.
     Dialog,
 
     /// The game is waiting for player

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,6 @@
 //! Game state handling module
 
 /// TODO: Finish documentation
-
 use rltk::{GameState, Rltk};
 use specs::prelude::*;
 
@@ -44,7 +43,7 @@ impl State {
 
         let mut potion_drink_system = PotionDrinkSystem {};
         potion_drink_system.run_now(&self.ecs);
-        
+
         let mut item_drop_system = ItemDropSystem {};
         item_drop_system.run_now(&self.ecs);
 
@@ -85,10 +84,8 @@ impl State {
         let renderers = self.ecs.read_storage::<Renderable>();
 
         let mut entities = (&positions, &renderers).join().collect::<Vec<_>>();
-        entities.sort_by(|&first, &second| {
-            second.1.order.cmp(&first.1.order)
-        });
-        
+        entities.sort_by(|&first, &second| second.1.order.cmp(&first.1.order));
+
         for (position, renderable) in entities.iter() {
             if map.is_tile_in_fov(position.x, position.y) {
                 ctx.set(

--- a/src/swatch.rs
+++ b/src/swatch.rs
@@ -1,7 +1,6 @@
 //! Module for color management
 
 /// TODO: Add remaining currently hardcoded colors to the swatch
-
 use rltk::RGB;
 
 /// The default background color for entities and tiles.

--- a/src/swatch.rs
+++ b/src/swatch.rs
@@ -1,5 +1,7 @@
 //! Module for color management
 
+/// TODO: Add remaining currently hardcoded colors to the swatch
+
 use rltk::RGB;
 
 /// The default background color for entities and tiles.

--- a/src/swatch.rs
+++ b/src/swatch.rs
@@ -56,19 +56,19 @@ pub const PLAYER_HEALTH_BAR: Pallet = Pallet(rltk::RED, DEFAULT_BG_COLOR);
 pub const MOUSE_CURSOR: U8Color = rltk::GOLD;
 
 /// Color for the tooltips.
-pub const TOOLTIP: Pallet = Pallet(rltk::WHITE, rltk::DARKRED);
+pub const TOOLTIP: Pallet = Pallet(rltk::WHITE, rltk::GOLDENROD);
 
 /// Color pallet for the health potion item.
 pub const HEALTH_POTION: Pallet = Pallet(rltk::CRIMSON, DEFAULT_BG_COLOR);
 
 /// The color pallet for dialog titles.
-pub const DIALOG_TITLE: Pallet = Pallet(rltk::WHITE, DEFAULT_BG_COLOR);
+pub const DIALOG_TITLE: Pallet = Pallet(rltk::GOLD, DEFAULT_BG_COLOR);
 
 /// The color pallet for dialog dismiss/cancel buttons.
-pub const DIALOG_DISMISS_BUTTON: Pallet = Pallet(rltk::WHITE, DEFAULT_BG_COLOR);
+pub const DIALOG_DISMISS_BUTTON: Pallet = Pallet(rltk::GOLDENROD, DEFAULT_BG_COLOR);
 
 /// The color pallet for dialog frames.
 pub const DIALOG_FRAME: Pallet = Pallet(rltk::WHITE, DEFAULT_BG_COLOR);
 
 /// Color pallet for dialog options.
-pub const DIALOG_OPTION: Pallet = Pallet(rltk::LIGHT_GOLDENROD, DEFAULT_BG_COLOR);
+pub const DIALOG_OPTION: Pallet = Pallet(rltk::GOLDENROD, DEFAULT_BG_COLOR);

--- a/src/swatch.rs
+++ b/src/swatch.rs
@@ -1,6 +1,5 @@
 //! Module for color management
 
-/// TODO: Add remaining currently hardcoded colors to the swatch
 use rltk::RGB;
 
 /// The default background color for entities and tiles.
@@ -10,14 +9,14 @@ pub const DEFAULT_BG_COLOR: (u8, u8, u8) = (0, 0, 0);
 type U8Color = (u8, u8, u8);
 
 /// A struct describing the foreground and
-/// background color of an entity or tiles.
+/// background color of an entity or tile.
 pub struct Pallet(pub U8Color, pub U8Color);
 
 impl Pallet {
     /// Transforms the [Pallet]'s foreground
     /// and background [U8Color] tuples to
     /// [RGB] structs and returns them in a tuple
-    /// in the same order `(fg, bg)`.
+    /// in the same order of `(fg, bg)`.
     pub fn colors(&self) -> (RGB, RGB) {
         let fg = self.0;
         let bg = self.1;
@@ -28,8 +27,6 @@ impl Pallet {
         )
     }
 }
-
-// (220, 206, 26)
 
 /// The player entity's color.
 pub const PLAYER: Pallet = Pallet(rltk::GOLD, DEFAULT_BG_COLOR);
@@ -63,3 +60,15 @@ pub const TOOLTIP: Pallet = Pallet(rltk::WHITE, rltk::DARKRED);
 
 /// Color pallet for the health potion item.
 pub const HEALTH_POTION: Pallet = Pallet(rltk::CRIMSON, DEFAULT_BG_COLOR);
+
+/// The color pallet for dialog titles.
+pub const DIALOG_TITLE: Pallet = Pallet(rltk::WHITE, DEFAULT_BG_COLOR);
+
+/// The color pallet for dialog dismiss/cancel buttons.
+pub const DIALOG_DISMISS_BUTTON: Pallet = Pallet(rltk::WHITE, DEFAULT_BG_COLOR);
+
+/// The color pallet for dialog frames.
+pub const DIALOG_FRAME: Pallet = Pallet(rltk::WHITE, DEFAULT_BG_COLOR);
+
+/// Color pallet for dialog options.
+pub const DIALOG_OPTION: Pallet = Pallet(rltk::LIGHT_GOLDENROD, DEFAULT_BG_COLOR);

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,15 +1,17 @@
 //! Module containing all systems of the game
 
 /// TODO: Add inline documentation for system executions
-
 use rltk::{a_star_search, console, field_of_view, Point, VirtualKeyCode};
 use specs::prelude::*;
 
-use crate::{DamageCounter, DialogInterface, DialogOption, Loot, PickupItem, Potion, Statistics, UsePotion, DropItem};
+use crate::{
+    DamageCounter, DialogInterface, DialogOption, DropItem, Loot, PickupItem, Potion, Statistics,
+    UsePotion,
+};
 
 use super::{
-    Collision, FOV, GameLog, Map, MeleeAttack, Monster, Name, Player, Position,
-    ProcessingState, pythagoras_distance,
+    pythagoras_distance, Collision, GameLog, Map, MeleeAttack, Monster, Name, Player, Position,
+    ProcessingState, FOV,
 };
 
 /// System that handles the field of view
@@ -101,7 +103,7 @@ impl<'a> System<'a> for MonsterAI {
 
         // Iterate through all monsters that have an fov
         for (entity, fov, _monster, position) in
-        (&entities, &mut fovs, &monsters, &mut positions).join()
+            (&entities, &mut fovs, &monsters, &mut positions).join()
         {
             let distance_to_player = pythagoras_distance(&position.to_point(), &*player_position);
 
@@ -274,8 +276,10 @@ impl DamageSystem {
             DialogInterface::register_dialog(
                 ecs,
                 "An untimely end".to_string(),
-                Some("You have died while exploring the dungeon! Restart the game and try again."
-                    .to_string()),
+                Some(
+                    "You have died while exploring the dungeon! Restart the game and try again."
+                        .to_string(),
+                ),
                 vec![DialogOption {
                     description: "Quit the game".to_string(),
                     key: VirtualKeyCode::Q,
@@ -365,26 +369,26 @@ impl<'a> System<'a> for ItemDropSystem {
 
     fn run(&mut self, data: Self::SystemData) {
         let (entities, mut game_log, names, mut loot, mut positions, mut drops) = data;
-        
+
         for (entity, drop) in (&entities, &drops).join() {
-            let entity_position =  positions.get(entity).unwrap();
-            
+            let entity_position = positions.get(entity).unwrap();
+
             let drop_position = Position {
                 x: entity_position.x,
                 y: entity_position.y,
             };
-            
+
             positions.insert(drop.item, drop_position).expect("");
             loot.remove(drop.item);
-            
+
             let entity_name = &names.get(entity).unwrap().name;
             let item_name = &names.get(drop.item).unwrap().name;
-            
+
             let log_message = format!("{} drops {}", entity_name, item_name);
-            
+
             game_log.messages_push(&log_message);
         }
-        
+
         drops.clear();
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,5 +1,7 @@
 //! Module containing all systems of the game
 
+/// TODO: Add inline documentation for system executions
+
 use rltk::{a_star_search, console, field_of_view, Point, VirtualKeyCode};
 use specs::prelude::*;
 

--- a/src/ui_controller.rs
+++ b/src/ui_controller.rs
@@ -1,5 +1,8 @@
 //! Module containing all UI functionality of the game
 
+/// TODO: Finish documentation
+
+
 use rltk::{Point, Rltk};
 use specs::prelude::*;
 

--- a/src/ui_controller.rs
+++ b/src/ui_controller.rs
@@ -1,8 +1,6 @@
 //! Module containing all UI functionality of the game
 
 /// TODO: Finish documentation
-
-
 use rltk::{Point, Rltk};
 use specs::prelude::*;
 

--- a/src/ui_controller.rs
+++ b/src/ui_controller.rs
@@ -1,6 +1,5 @@
 //! Module containing all UI functionality of the game
 
-/// TODO: Finish documentation
 use rltk::{Point, Rltk};
 use specs::prelude::*;
 
@@ -15,18 +14,25 @@ use super::{
 /// * `ctx`: The console context in which the ui should be drawn.
 ///
 /// # See also
-/// * [draw_message_log]: Draws the message log box at the bottom of the screen.
-/// * [draw_player_health]: Draws the players health information and a corresponding health bar
-/// on top of the
+/// * [draw_message_log]
+/// * [draw_messages]
+/// * [draw_player_health]
+/// * [draw_mouse_cursor]
 ///
 pub fn draw_ui(ecs: &World, ctx: &mut Rltk) {
     draw_message_log(ctx);
     draw_messages(ecs, ctx);
     draw_player_health(ecs, ctx);
     draw_mouse_cursor(ctx);
-    draw_tooltips(ecs, ctx);
 }
 
+/// Draws the games message log at the bottom of the
+/// Screen.
+///
+/// # Arguments
+/// * `ctx`: The [Rltk] context in which the message log
+/// should be drawn.
+///
 fn draw_message_log(ctx: &mut Rltk) {
     let (x, y) = (0, config::MAP_HEIGHT);
     let (width, height) = (
@@ -38,6 +44,14 @@ fn draw_message_log(ctx: &mut Rltk) {
     ctx.draw_box(x, y, width, height, fg, bg);
 }
 
+/// Writes the messages which are stored in the [GameLog]
+/// struct of the `ecs` inside the message log ui.
+///
+/// # Arguments
+/// * `ecs`: THe [World] in which the [GameLog] is stored.
+/// * `ctx`: The [Rltk] context in which the messages should
+/// be written.
+///
 fn draw_messages(ecs: &World, ctx: &mut Rltk) {
     let mut game_log = ecs.fetch_mut::<GameLog>();
 
@@ -45,7 +59,7 @@ fn draw_messages(ecs: &World, ctx: &mut Rltk) {
     let mut y = config::MAP_HEIGHT + 1;
 
     game_log.messages_for_each_rev(|message| {
-        if y < config::WINDOW_HEIGHT - 1 {
+        if y < config::WINDOW_HEIGHT - 2 {
             let timestamp = timestamp_formatted();
             ctx.print(x, y, &format!("{} > {}", timestamp, message));
             y += 1;
@@ -53,6 +67,13 @@ fn draw_messages(ecs: &World, ctx: &mut Rltk) {
     })
 }
 
+/// Draws the players healh information in form of status
+/// text and a health bar on top of the message log ui.
+///
+/// # Arguments
+/// * `ecs`: The [World] in which the player is stored.
+/// * `ctx`: The [Rltk] context in which the ui should be drawn.
+///
 fn draw_player_health(ecs: &World, ctx: &mut Rltk) {
     let players = ecs.read_storage::<Player>();
     let statistics = ecs.read_storage::<Statistics>();
@@ -78,12 +99,29 @@ fn draw_player_health(ecs: &World, ctx: &mut Rltk) {
     }
 }
 
+/// Sets the background color of the
+/// tile currently focused by the mouse cursor.
+///
+/// # Arguments
+/// * `ctx`: The [Rltk] context in which the mouse cursor
+/// should be highlighted.
+///
+/// # See also
+/// * [swatch::Mouse_Cursor]
+///
 fn draw_mouse_cursor(ctx: &mut Rltk) {
     let (x, y) = ctx.mouse_pos();
     ctx.set_bg(x, y, swatch::MOUSE_CURSOR);
 }
 
-fn draw_tooltips(ecs: &World, ctx: &mut Rltk) {
+/// Draws a tooltip displaying the name of all entities
+/// on a tile, when the mouse is hovered over it.
+///
+/// # Arguments
+/// * `ecs`: The [World] struct, required to read the entities names and positions.
+/// * `ctx`: The [Rltk] context in which the tooltips should be drawn.
+///
+pub fn draw_tooltips(ecs: &World, ctx: &mut Rltk) {
     let map = ecs.fetch::<Map>();
     let names = ecs.read_storage::<Name>();
     let positions = ecs.read_storage::<Position>();

--- a/web/templates/manifest.json
+++ b/web/templates/manifest.json
@@ -1,5 +1,5 @@
 {
- "name": "App",
+ "name": "B_Ruge",
  "icons": [
   {
    "src": "\/android-icon-36x36.png",


### PR DESCRIPTION
## [B_Ruge]

### [0.2.8] - 19.09.2021

#### Added

* Added badge for web deployment preview to readme
* Added components and system to allow entities to drop items
* Added render order for entities and tiles
* Added components for the creation of items
* Added health potion item
* Added system to pick up and use items
* Added item and potion components
* Added potion usage system
* Added inventory dialog
* Added seeded random number generator

#### Changed

* Bumped version to 0.2.8 
* Game is now initialized with a seed based on the current time in nanoseconds
* Started to move plain text exception messages to a custom module for better maintainability
* Removed unnecessary domain alias from web preview deployment workflow yaml
* Separated web deployment workflow into preview for dev and production for main
* Reworked DialogInterface and DialogOptions to now incorporate a memory safe generic way to create callbacks and 
make them safely callable at any part of the game
* Reworked entity_factory spawning
* Modified deploy_web.yml to fire when pushed on dev and when a pull request is set for the main branch* Modified
deploy_web.yml to fire when pushed on dev and when a pull request is set for the main branch
* Update CHANGELOG.md
* Finished documentation for next release
* Moved remaining hardcoded colors to swatch 
* Updated manifest.json in the web templates to show the games correct name
* Updated inventory text for use and drop item
* Extended documentation

#### Fixes

* Fixed display issue of workflow badge deploy-web
* Corrected error in dialog display logic, causing dialogs without a text to display items of center 
